### PR TITLE
Error when using the bundle in conjunction with the console

### DIFF
--- a/src/Loader/ConfigLoader.php
+++ b/src/Loader/ConfigLoader.php
@@ -127,7 +127,7 @@ class ConfigLoader {
 
         define( 'WP_SITEURL', $wp_siteurl);
 
-        if(isset($_SERVER['SERVER_NAME']) and filter_var($_SERVER['SERVER_NAME'], FILTER_VALIDATE_IP) !== false)
+        if(isset($_SERVER['SERVER_NAME']) && filter_var($_SERVER['SERVER_NAME'], FILTER_VALIDATE_IP) !== false)
             define('COOKIE_DOMAIN', '' );
         else
             define( 'COOKIE_DOMAIN', strtok($_SERVER[ 'HTTP_HOST' ], ':') );

--- a/src/Loader/ConfigLoader.php
+++ b/src/Loader/ConfigLoader.php
@@ -127,7 +127,7 @@ class ConfigLoader {
 
         define( 'WP_SITEURL', $wp_siteurl);
 
-        if(filter_var($_SERVER['SERVER_NAME'], FILTER_VALIDATE_IP) !== false)
+        if(isset($_SERVER['SERVER_NAME']) and filter_var($_SERVER['SERVER_NAME'], FILTER_VALIDATE_IP) !== false)
             define('COOKIE_DOMAIN', '' );
         else
             define( 'COOKIE_DOMAIN', strtok($_SERVER[ 'HTTP_HOST' ], ':') );


### PR DESCRIPTION
In some configurations, no server name is given when using the console application. To avoid errors when setting the cookie, an additional check is made to see if the server name is available.