### PR TITLE
Fix reference to global namespace class

### DIFF
--- a/src/Plugin/CachePlugin.php
+++ b/src/Plugin/CachePlugin.php
@@ -80,7 +80,7 @@ class CachePlugin
         if( $this->debug )
             return;
 
-        $results = WPS_Object_Cache::purgeUrl($url);
+        $results = \WPS_Object_Cache::purgeUrl($url);
 
         foreach ($results as $result){
 
@@ -101,7 +101,7 @@ class CachePlugin
 	 */
 	private function clear()
 	{
-		if ( !WPS_Object_Cache::clear() )
+		if ( !\WPS_Object_Cache::clear() )
 			$this->errorMessage[] = 'Unable to clear cache';
 		else
 			$this->noticeMessage[] = 'Cleared';


### PR DESCRIPTION
Hi! I've found this bug that can be replicated by setting up the project (or using the 2.0.x branch of the Demo repo), activating the `wp-steroids` plug-in, navigating to the Wordpress permalink config page and clicking on "save".

It complains that cannot find the  `WPS_Object_Cache` class that is loaded within the `wp-steroids` plug-in.

By prefixing the class with a backslash it works, as it now correctly picks it up from the global namespace.