### PR TITLE
Use Symfony trailing slash policy in Page routes

### DIFF
--- a/config/routing.php
+++ b/config/routing.php
@@ -146,7 +146,7 @@ class Permastruct{
             $this->addRoute('search', $this->wp_rewrite->search_structure, [], true);
 
         if( isset($this->wp_rewrite->page_structure) )
-            $this->addRoute('page', $this->wp_rewrite->page_structure, ['pagename'=>'[a-zA-Z0-9]{2}[^/].*']);
+            $this->addRoute('page', $this->wp_rewrite->page_structure, ['pagename'=>'[a-zA-Z0-9]{2}[^/].*[^/]']);
 
         if( isset($this->wp_rewrite->permalink_structure) && (!isset($this->wp_rewrite->page_structure) || str_replace('%pagename%','', $this->wp_rewrite->page_structure) != str_replace('/%postname%','', $this->wp_rewrite->permalink_structure)) )
             $this->addRoute('post', $this->wp_rewrite->permalink_structure, ['postname'=>'[a-zA-Z0-9]{2}[^/].*']);


### PR DESCRIPTION
When a route is defined without trailing slash Symfony redirects with 301 to it when accessing the same URL with trailing slash. However in the current Page route definition the `pagename` parameter would accept anything including trailing slashes and Wordpress would find it and return the correct post, causing 200 responses both in the `/{slug}` page as well as the `/{slug}/`, which hurts SEO.

Given that and knowing that Wordpress won't allow slashes in slugs, we change the `pagename` regex to reject trailing slashes and therefore serve 200 responses on naked slugs and 301 on trailing slashes, as expected.