### PR TITLE
Fix type errors with PHP 8.x

### DIFF
--- a/src/ArgumentResolver/PostValueResolver.php
+++ b/src/ArgumentResolver/PostValueResolver.php
@@ -30,6 +30,10 @@ class PostValueResolver implements ArgumentValueResolverInterface {
      */
     public function supports(Request $request, ArgumentMetadata $argument)
     {
+        if(is_null($argument->getType()) || !class_exists($argument->getType())) {
+            return false;
+        }
+        
         return Post::class === $argument->getType() || get_parent_class($argument->getType()) == Post::class;
     }
 

--- a/src/Entity/Menu.php
+++ b/src/Entity/Menu.php
@@ -21,7 +21,7 @@ class Menu extends Entity
 
     public static $locations;
 
-    public function __toString(): ?string
+    public function __toString(): string
     {
         return $this->title??'';
     }


### PR DESCRIPTION
Hi, thank you for your bundle, it works like a charm with Sylius.

I have encountered two minor compatibility issues with PHP 8.0 :

- __toString now always return string, the question mark is not necessarly
- from 8.0, "get_parent_class" parameter only accepts existing object or class name. In this case it can be "null" so we have to check it first to prevent a fatal error